### PR TITLE
Fix typo introduced in 7e41603

### DIFF
--- a/phonemes.json
+++ b/phonemes.json
@@ -392,7 +392,7 @@
         }
     },
     "ʃʲ": {
-        "name": "palatalized voiceless palato-alveolar sibilant",
+        "name": "palatalised voiceless palato-alveolar sibilant",
         "features": {
             "cons": true,
             "son": false,


### PR DESCRIPTION
When I renamed `ʃʲ`, I inconsistently used the American spelling of “palatalised”.